### PR TITLE
Install psutil through pytest-xdist

### DIFF
--- a/reusable-actions/pytest/action.yml
+++ b/reusable-actions/pytest/action.yml
@@ -33,7 +33,7 @@ runs:
         requirements-txt: ${{ inputs.requirements-txt }}
         build-command: ${{ inputs.build-command }}
     - name: Install pytest and other dependencies for testing
-      run: pip install pytest pytest-cov pytest-xdist psutil
+      run: pip install pytest pytest-cov pytest-xdist[psutil]
       shell: bash
     - name: Run pytest and capture code coverage
       run: pytest --cov --junitxml=pytest-test-report.xml -n logical ${{ inputs.pytest-args }}


### PR DESCRIPTION
See https://pytest-xdist.readthedocs.io/en/stable/index.html?highlight=psutil#installation

This will handle requirements, if they have any (e.g. if they had `psutil<3.0` or similar [here](https://github.com/pytest-dev/pytest-xdist/blob/8fbecd8a23bd927a1f7982fd385a9fab78deb843/setup.cfg#L59))